### PR TITLE
fix(rel-urls): use first non-empty text value and get type

### DIFF
--- a/src/rels/rels.ts
+++ b/src/rels/rels.ts
@@ -17,6 +17,7 @@ export const parseRel = (
   const title = getAttributeValue(child, "title");
   const media = getAttributeValue(child, "media");
   const hreflang = getAttributeValue(child, "hreflang");
+  const type = getAttributeValue(child, "type");
 
   /* istanbul ignore if */
   if (!rel || !href) {
@@ -52,6 +53,10 @@ export const parseRel = (
 
     if (hreflang && !relUrls[href].hreflang) {
       relUrls[href].hreflang = hreflang;
+    }
+
+    if (type && !relUrls[href].type) {
+      relUrls[href].type = type;
     }
   });
 };

--- a/src/rels/rels.ts
+++ b/src/rels/rels.ts
@@ -11,6 +11,7 @@ export const parseRel = (
   child: ParentNode,
   { rels, relUrls }: ParseRelOptions
 ): void => {
+  const text = relTextContent(child);
   const rel = getAttributeValue(child, "rel");
   const href = getAttributeValue(child, "href");
   const title = getAttributeValue(child, "title");
@@ -32,20 +33,24 @@ export const parseRel = (
     }
 
     if (!relUrls[href]) {
-      relUrls[href] = { rels: [rel], text: relTextContent(child) };
+      relUrls[href] = { rels: [rel], text };
     } else if (!relUrls[href].rels.includes(rel)) {
       relUrls[href].rels.push(rel);
     }
 
-    if (title) {
+    if (text && !relUrls[href].text) {
+      relUrls[href].text = text;
+    }
+
+    if (title && !relUrls[href].title) {
       relUrls[href].title = title;
     }
 
-    if (media) {
+    if (media && !relUrls[href].media) {
       relUrls[href].media = media;
     }
 
-    if (hreflang) {
+    if (hreflang && !relUrls[href].hreflang) {
       relUrls[href].hreflang = hreflang;
     }
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,7 @@ export type RelUrls = Record<
     title?: string;
     media?: string;
     hreflang?: string;
+    type?: string;
   }
 >;
 

--- a/test/rel-urls.spec.ts
+++ b/test/rel-urls.spec.ts
@@ -1,0 +1,28 @@
+import { expect } from "chai";
+
+import { mf2 } from "../src";
+
+describe("specification // rel-urls", () => {
+  describe("with multiple rels", () => {
+    it("should take the first non-empty value for name", () => {
+      const input = `<link rel="me" href="http://example.com"><a rel="me" href="http://example.com">My name</a><a rel="home" href="http://example.com">Go back home</a>`;
+      const expected = {
+        rels: {
+          me: ["http://example.com"],
+          home: ["http://example.com"],
+        },
+        "rel-urls": {
+          "http://example.com": {
+            rels: ["me", "home"],
+            text: "My name",
+          },
+        },
+        items: [],
+      };
+
+      expect(mf2(input, { baseUrl: "http://example.com" })).to.deep.equal(
+        expected
+      );
+    });
+  });
+});

--- a/test/rel-urls.spec.ts
+++ b/test/rel-urls.spec.ts
@@ -25,4 +25,25 @@ describe("specification // rel-urls", () => {
       );
     });
   });
+
+  it("should report the rel type attribute", () => {
+    const input = `<div><a rel="me" href="http://example.com" type="text/html">My name</a></div>`;
+    const expected = {
+      rels: {
+        me: ["http://example.com"],
+      },
+      "rel-urls": {
+        "http://example.com": {
+          rels: ["me"],
+          text: "My name",
+          type: "text/html",
+        },
+      },
+      items: [],
+    };
+
+    expect(mf2(input, { baseUrl: "http://example.com" })).to.deep.equal(
+      expected
+    );
+  });
 });


### PR DESCRIPTION
Fixes:
- rel-urls not reporting the type attribute from the link
- rel-urls returning an empty string for text when there are multiple links, the first without any text (see https://github.com/microformats/microformats2-parsing/issues/50)