### PR TITLE
Add support for parsing the `lang` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,13 @@ Outputs:
 
 ### mf2()
 
-Use: `mf2(html: string, options: { baseUrl: string })`
+Use: `mf2(html: string, options: { baseUrl: string, experimental: object })`
 
 - `html` (string, required) - the HTML string to be parsed
 - `options` (object, required) - parsing options, with the following properties:
   - `baseUrl` (string, required) - a base URL to resolve relative URLs
+  - `experimental` (object, optional) - experimental (non-standard) options
+    - `lang` (boolean, optional) - whether to enable support for parsing `lang` attributes
 
 Returns the parsed microformats from the HTML string
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microformats-parser",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A JavaScript microformats v2 parser",
   "main": "dist/index.js",
   "homepage": "https://aimee-gm.github.io/microformats-parser/",

--- a/src/helpers/attributes.ts
+++ b/src/helpers/attributes.ts
@@ -3,7 +3,13 @@ import { ParentNode, Attribute } from "../types";
 export const getAttribute = (
   node: ParentNode,
   name: string
-): Attribute | undefined => node.attrs.find((attr) => attr.name === name);
+): Attribute | undefined => {
+  if (node && node.attrs) {
+    return node.attrs.find((attr) => attr.name === name);
+  }
+
+  return undefined;
+};
 
 export const getAttributeValue = (
   node: ParentNode,

--- a/src/helpers/attributes.ts
+++ b/src/helpers/attributes.ts
@@ -5,13 +5,7 @@ import { ParentNode } from "../types";
 export const getAttribute = (
   node: ParentNode,
   name: string
-): Attribute | undefined => {
-  if (node && node.attrs) {
-    return node.attrs.find((attr) => attr.name === name);
-  }
-
-  return undefined;
-};
+): Attribute | undefined => node.attrs.find((attr) => attr.name === name);
 
 export const getAttributeValue = (
   node: ParentNode,

--- a/src/helpers/documentSetup.ts
+++ b/src/helpers/documentSetup.ts
@@ -9,6 +9,9 @@ interface DocumentSetupResult {
   rels: Rels;
   relUrls: RelUrls;
   baseUrl: string;
+  experimental?: {
+    lang?: boolean;
+  };
 }
 
 export const findBase = (node: ParentNode): string | undefined => {
@@ -91,6 +94,7 @@ export const documentSetup = (
     rels: {},
     relUrls: {},
     baseUrl: findBase(node) ?? options.baseUrl,
+    experimental: options.experimental,
   };
 
   handleNode(node, result);

--- a/src/helpers/documentSetup.ts
+++ b/src/helpers/documentSetup.ts
@@ -9,9 +9,6 @@ interface DocumentSetupResult {
   rels: Rels;
   relUrls: RelUrls;
   baseUrl: string;
-  experimental?: {
-    lang?: boolean;
-  };
 }
 
 export const findBase = (node: ParentNode): string | undefined => {
@@ -94,7 +91,6 @@ export const documentSetup = (
     rels: {},
     relUrls: {},
     baseUrl: findBase(node) ?? options.baseUrl,
-    experimental: options.experimental,
   };
 
   handleNode(node, result);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,9 @@ import { ParsedDocument } from "./types";
 
 export interface Options {
   baseUrl: string;
+  experimental?: {
+    lang?: boolean;
+  };
 }
 
 export const mf2 = (html: string, options: Options): ParsedDocument => {

--- a/src/microformats/parse.ts
+++ b/src/microformats/parse.ts
@@ -73,7 +73,7 @@ export const parseMicroformat = (
     item.id = id;
   }
 
-  if (lang && options.experimental && options.experimental.lang) {
+  if (lang && options.experimental?.lang) {
     item.lang = lang;
   }
 

--- a/src/microformats/parse.ts
+++ b/src/microformats/parse.ts
@@ -73,7 +73,7 @@ export const parseMicroformat = (
     item.id = id;
   }
 
-  if (lang && options.experimental?.lang) {
+  if (lang && options.experimental && options.experimental.lang) {
     item.lang = lang;
   }
 

--- a/src/microformats/parse.ts
+++ b/src/microformats/parse.ts
@@ -36,6 +36,18 @@ const getRoots = (node: ParentNode): BackcompatRoot[] =>
 const getId = (node: ParentNode): string | undefined =>
   isMicroformatV2Root(node) ? getAttributeValue(node, "id") : undefined;
 
+const getLanguage = (node: ParentNode): string | undefined => {
+  const lang = getAttributeValue(node, "lang");
+
+  if (lang) {
+    return lang;
+  } else if (node.parentNode) {
+    return getLanguage(node.parentNode);
+  }
+
+  return undefined;
+};
+
 export const parseMicroformat = (
   node: ParentNode,
   options: ParseMicroformatOptions
@@ -44,6 +56,7 @@ export const parseMicroformat = (
 
   const roots = getRoots(node);
   const id = getId(node);
+  const lang = getLanguage(node);
   const children = findChildren(node, isMicroformatChild, options);
 
   const item: MicroformatRoot = {
@@ -57,6 +70,10 @@ export const parseMicroformat = (
 
   if (id) {
     item.id = id;
+  }
+
+  if (lang && options.experimental && options.experimental.lang) {
+    item.lang = lang;
   }
 
   if (children.length) {

--- a/src/microformats/parse.ts
+++ b/src/microformats/parse.ts
@@ -11,6 +11,7 @@ import { findChildren } from "../helpers/findChildren";
 import {
   isMicroformatChild,
   isMicroformatV2Root,
+  isParentNode,
 } from "../helpers/nodeMatchers";
 import {
   convertV1RootClassNames,
@@ -41,7 +42,7 @@ const getLanguage = (node: ParentNode): string | undefined => {
 
   if (lang) {
     return lang;
-  } else if (node.parentNode) {
+  } else if (node.parentNode && isParentNode(node.parentNode)) {
     return getLanguage(node.parentNode);
   }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -14,12 +14,9 @@ export const parser = (
   const doc = parse(html) as ParentNode;
   validateParsedHtml(doc);
 
-  const { idRefs, rels, relUrls, baseUrl, experimental } = documentSetup(
-    doc,
-    options
-  );
+  const { idRefs, rels, relUrls, baseUrl } = documentSetup(doc, options);
 
-  const parsingOptions = { baseUrl, experimental, roots: [], idRefs };
+  const parsingOptions = { ...options, baseUrl, roots: [], idRefs };
 
   return {
     rels,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -14,9 +14,12 @@ export const parser = (
   const doc = parse(html) as ParentNode;
   validateParsedHtml(doc);
 
-  const { idRefs, rels, relUrls, baseUrl } = documentSetup(doc, options);
+  const { idRefs, rels, relUrls, baseUrl, experimental } = documentSetup(
+    doc,
+    options
+  );
 
-  const parsingOptions = { baseUrl, roots: [], idRefs };
+  const parsingOptions = { baseUrl, experimental, roots: [], idRefs };
 
   return {
     rels,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,9 @@ import { BackcompatRoot } from "./backcompat";
 
 export interface ParserOptions {
   baseUrl: string;
+  experimental?: {
+    lang?: boolean;
+  };
 }
 
 export interface ParsingOptions extends ParserOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface Attribute {
 
 export interface ParentNode {
   attrs: Attribute[];
+  parentNode: ParentNode;
   childNodes: (ParentNode | TextNode)[];
   tagName: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export type MicroformatProperties = Record<string, MicroformatProperty[]>;
 
 export interface MicroformatRoot {
   id?: string;
+  lang?: string;
   type?: string[];
   properties: MicroformatProperties;
   children?: MicroformatRoot[];

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -44,6 +44,28 @@ export const validator = (html: unknown, options: unknown): void => {
 
   // verify the url provided is valid
   new URL(baseUrl);
+
+  // eslint-disable-next-line
+  //@ts-ignore
+  const { experimental } = options;
+
+  if (typeof experimental !== "undefined" && typeof experimental !== "object") {
+    throw new TypeError("Microformats parser: experimental is not an object");
+  }
+
+  if (typeof experimental === "object" && Array.isArray(experimental)) {
+    throw new TypeError("Microformats parser: experimental is not an object");
+  }
+
+  if (
+    experimental &&
+    "lang" in experimental &&
+    typeof experimental.lang !== "boolean"
+  ) {
+    throw new TypeError(
+      "Microformats parser: experimental.lang is not a boolean"
+    );
+  }
 };
 
 export const validateParsedHtml = (doc: ParentNode): void => {

--- a/test/scenarios.spec.ts
+++ b/test/scenarios.spec.ts
@@ -20,9 +20,6 @@ const experimental = loadScenarios(suitesDir, "experimental");
 
 const options = {
   baseUrl: "http://example.com",
-  experimental: {
-    lang: true,
-  },
 };
 
 describe("mf2() // scenarios", () => {
@@ -66,7 +63,10 @@ describe("mf2() // local scenarios", () => {
 describe("mf2() // experimental scenarios", () => {
   experimental.forEach(({ name, input, expected }) => {
     it(`should correctly parse ${name}`, () => {
-      const result = mf2(input, options);
+      const result = mf2(
+        input,
+        Object.assign(options, { experimental: { lang: true } })
+      );
       expect(result).to.deep.equal(expected);
     });
   });

--- a/test/scenarios.spec.ts
+++ b/test/scenarios.spec.ts
@@ -16,9 +16,13 @@ const v1 = loadScenarios(scenarioDir, "microformats-v1");
 const v2 = loadScenarios(scenarioDir, "microformats-v2");
 const mixed = loadScenarios(scenarioDir, "microformats-mixed");
 const local = loadScenarios(suitesDir, "local");
+const experimental = loadScenarios(suitesDir, "experimental");
 
 const options = {
   baseUrl: "http://example.com",
+  experimental: {
+    lang: true,
+  },
 };
 
 describe("mf2() // scenarios", () => {
@@ -52,6 +56,15 @@ describe("mf2() // scenarios", () => {
 
 describe("mf2() // local scenarios", () => {
   local.forEach(({ name, input, expected }) => {
+    it(`should correctly parse ${name}`, () => {
+      const result = mf2(input, options);
+      expect(result).to.deep.equal(expected);
+    });
+  });
+});
+
+describe("mf2() // experimental scenarios", () => {
+  experimental.forEach(({ name, input, expected }) => {
     it(`should correctly parse ${name}`, () => {
       const result = mf2(input, options);
       expect(result).to.deep.equal(expected);

--- a/test/suites/experimental/lang-feed.html
+++ b/test/suites/experimental/lang-feed.html
@@ -1,0 +1,2 @@
+<!-- From: https://github.com/microformats/php-mf2/blob/87da7b37350b9e99de85d457b12117472a06024c/tests/Mf2/ParseLanguageTest.php#L122 -->
+<html> <div class="h-feed" lang="en"> <h1 class="p-name">Test Feed</h1> <div class="h-entry">This test is in English.</div> <div class="h-entry" lang="es">Esta prueba está en español.</div> <div class="h-entry" lang="fr">Ce test est en français.</div> </html>

--- a/test/suites/experimental/lang-feed.json
+++ b/test/suites/experimental/lang-feed.json
@@ -1,0 +1,36 @@
+{
+  "items": [
+    {
+      "type": ["h-feed"],
+      "lang": "en",
+      "properties": {
+        "name": ["Test Feed"]
+      },
+      "children": [
+        {
+          "type": ["h-entry"],
+          "lang": "en",
+          "properties": {
+            "name": ["This test is in English."]
+          }
+        },
+        {
+          "type": ["h-entry"],
+          "lang": "es",
+          "properties": {
+            "name": ["Esta prueba está en español."]
+          }
+        },
+        {
+          "type": ["h-entry"],
+          "lang": "fr",
+          "properties": {
+            "name": ["Ce test est en français."]
+          }
+        }
+      ]
+    }
+  ],
+  "rels": {},
+  "rel-urls": {}
+}

--- a/test/suites/experimental/lang.html
+++ b/test/suites/experimental/lang.html
@@ -1,0 +1,17 @@
+<!-- From: https://github.com/microformats/php-mf2/blob/87da7b37350b9e99de85d457b12117472a06024c/tests/Mf2/ParseLanguageTest.php#L22 -->
+<html lang="en"> <div class="h-entry">This test is in English.</div> </html>
+
+<!-- From: https://github.com/microformats/php-mf2/blob/87da7b37350b9e99de85d457b12117472a06024c/tests/Mf2/ParseLanguageTest.php#L36 -->
+<html> <div class="h-entry" lang="en">This test is in English.</div> </html>
+
+<!-- From: https://github.com/microformats/php-mf2/blob/87da7b37350b9e99de85d457b12117472a06024c/tests/Mf2/ParseLanguageTest.php#L50 -->
+<html lang="en"> <div class="h-entry" lang="es">Esta prueba está en español.</div> </html>
+
+<!-- From: https://github.com/microformats/php-mf2/blob/87da7b37350b9e99de85d457b12117472a06024c/tests/Mf2/ParseLanguageTest.php#L64 -->
+<div class="h-entry" lang="en">This test is in English.</div>
+
+<!-- From: https://github.com/microformats/php-mf2/blob/87da7b37350b9e99de85d457b12117472a06024c/tests/Mf2/ParseLanguageTest.php#L105 -->
+<html lang="en"> <div class="h-entry">This test is in English.</div> <div class="h-entry" lang="es">Esta prueba está en español.</div> </html>
+
+<!-- From: https://github.com/microformats/php-mf2/blob/87da7b37350b9e99de85d457b12117472a06024c/tests/Mf2/ParseLanguageTest.php#L255 -->
+<div class="h-entry" lang="sv" id="postfrag123"><h1 class="p-name">En svensk titel</h1><div class="e-content" lang="en">With an <em>english</em> summary</div><div class="e-content">Och <em>svensk</em> huvudtext</div></div>

--- a/test/suites/experimental/lang.json
+++ b/test/suites/experimental/lang.json
@@ -1,0 +1,66 @@
+{
+  "items": [
+    {
+      "type": ["h-entry"],
+      "lang": "en",
+      "properties": {
+        "name": ["This test is in English."]
+      }
+    },
+    {
+      "type": ["h-entry"],
+      "lang": "en",
+      "properties": {
+        "name": ["This test is in English."]
+      }
+    },
+    {
+      "type": ["h-entry"],
+      "lang": "es",
+      "properties": {
+        "name": ["Esta prueba está en español."]
+      }
+    },
+    {
+      "type": ["h-entry"],
+      "lang": "en",
+      "properties": {
+        "name": ["This test is in English."]
+      }
+    },
+    {
+      "type": ["h-entry"],
+      "lang": "en",
+      "properties": {
+        "name": ["This test is in English."]
+      }
+    },
+    {
+      "type": ["h-entry"],
+      "lang": "es",
+      "properties": {
+        "name": ["Esta prueba está en español."]
+      }
+    },
+    {
+      "type": ["h-entry"],
+      "lang": "sv",
+      "id": "postfrag123",
+      "properties": {
+        "name": ["En svensk titel"],
+        "content": [
+          {
+            "html": "With an <em>english</em> summary",
+            "value": "With an english summary"
+          },
+          {
+            "html": "Och <em>svensk</em> huvudtext",
+            "value": "Och svensk huvudtext"
+          }
+        ]
+      }
+    }
+  ],
+  "rels": {},
+  "rel-urls": {}
+}

--- a/test/validation.spec.ts
+++ b/test/validation.spec.ts
@@ -106,5 +106,30 @@ describe("validation", () => {
         );
       });
     });
+
+    describe("experimental", () => {
+      it("should throw an error if it is not an object", () => {
+        expect(() =>
+          mf2(html, { baseUrl: "http://example.com", experimental: "" })
+        ).to.throw("Microformats parser: experimental is not an object");
+      });
+
+      it("should throw an error if it is not an object", () => {
+        expect(() =>
+          mf2(html, { baseUrl: "http://example.com", experimental: [] })
+        ).to.throw("Microformats parser: experimental is not an object");
+      });
+
+      describe("lang", () => {
+        it("should throw an error if it is not a boolean", () => {
+          expect(() =>
+            mf2(html, {
+              baseUrl: "http://example.com",
+              experimental: { lang: "true" },
+            })
+          ).to.throw("Microformats parser: experimental.lang is not a boolean");
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
As discussed in #10.

* `$ yarn build` passes
* `$ yarn lint` passes
* `$ yarn test` passes
* `$ yarn prettier:list` (kind of) passes (complains only about files in `dist/`)

I hope this is up to your standards, feedback very welcome!