### PR TITLE
chore(typings): switch custom typings to parse5

### DIFF
--- a/src/helpers/attributes.ts
+++ b/src/helpers/attributes.ts
@@ -1,4 +1,6 @@
-import { ParentNode, Attribute } from "../types";
+import { Attribute } from "parse5";
+
+import { ParentNode } from "../types";
 
 export const getAttribute = (
   node: ParentNode,

--- a/src/helpers/nodeMatchers.ts
+++ b/src/helpers/nodeMatchers.ts
@@ -1,3 +1,5 @@
+import { DefaultTreeTextNode } from "parse5";
+
 import { MixedNode, ParentNode } from "../types";
 import {
   getAttribute,
@@ -18,6 +20,9 @@ const propClassRegex = classRegex("(p|e|u|dt)");
 
 export const isParentNode = (node: MixedNode): node is ParentNode =>
   Boolean(node.hasOwnProperty("tagName") && node.hasOwnProperty("childNodes"));
+
+export const isTextNode = (node: MixedNode): node is DefaultTreeTextNode =>
+  Boolean(node.hasOwnProperty("value"));
 
 export const isMicroformatV2Root = (node: ParentNode): boolean =>
   getClassNames(node).some((cl) => cl.match(rootClassRegex));

--- a/src/helpers/textContent.ts
+++ b/src/helpers/textContent.ts
@@ -1,10 +1,9 @@
 import { MixedNode, ParentNode } from "../types";
 import { getAttributeValue } from "./attributes";
-
-const isParentNode = (node: MixedNode): node is ParentNode =>
-  Boolean(node.hasOwnProperty("tagName") && node.hasOwnProperty("childNodes"));
+import { isParentNode, isTextNode } from "./nodeMatchers";
 
 const walk = (current: string, node: MixedNode): string => {
+  /* istanbul ignore else */
   if (isParentNode(node)) {
     if (["style", "script"].includes(node.tagName)) {
       return current;
@@ -20,12 +19,16 @@ const walk = (current: string, node: MixedNode): string => {
     }
 
     return node.childNodes.reduce<string>(walk, current);
-  } else {
+  } else if (isTextNode(node)) {
     return `${current}${node.value}`;
   }
+
+  /* istanbul ignore next */
+  return current;
 };
 
 const impliedWalk = (current: string, node: MixedNode): string => {
+  /* istanbul ignore else */
   if (isParentNode(node)) {
     if (["style", "script"].includes(node.tagName)) {
       return current;
@@ -37,9 +40,12 @@ const impliedWalk = (current: string, node: MixedNode): string => {
     }
 
     return node.childNodes.reduce<string>(impliedWalk, current);
-  } else {
+  } else if (isTextNode(node)) {
     return `${current}${node.value}`;
   }
+
+  /* istanbul ignore next */
+  return current;
 };
 
 export const textContent = (node: ParentNode): string =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
+import {
+  DefaultTreeElement,
+  DefaultTreeNode,
+  DefaultTreeTextNode,
+} from "parse5";
+
 import { BackcompatRoot } from "./backcompat";
 
 export interface ParserOptions {
@@ -16,22 +22,8 @@ export interface ParsedDocument {
   items: MicroformatRoot[];
 }
 
-export interface Attribute {
-  name: string;
-  value: string;
-}
-
-export interface ParentNode {
-  attrs: Attribute[];
-  childNodes: (ParentNode | TextNode)[];
-  tagName: string;
-}
-
-export interface TextNode {
-  value: string;
-}
-
-export type MixedNode = ParentNode | TextNode;
+export type ParentNode = DefaultTreeElement;
+export type MixedNode = ParentNode | DefaultTreeTextNode | DefaultTreeNode;
 
 export type MicroformatProperties = Record<string, MicroformatProperty[]>;
 


### PR DESCRIPTION
Adds a `parentNode` definition to the HTML nodes typings.