### PR TITLE
Add `.prettierignore`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+dist/
+.nyc_output/
+


### PR DESCRIPTION
This pull request adds a `.prettierignore` file that excludes the `.nyc_output/` and `dist/` directories from the checks run by prettier.

Previously, prettier would fail with a non-zero exit code and complain about auto-generated files when running `$ yarn prettier:list` during development.