### PR TITLE
feat(validation): validate options input for unrecognised keys

### DIFF
--- a/src/validator.ts
+++ b/src/validator.ts
@@ -27,6 +27,7 @@ const assertIsBoolean = (bool: unknown, name: string): boolean => {
 
 const assertIsObject = (
   obj: unknown,
+  allowedKeys: string[],
   name: string
 ): Record<string, unknown> => {
   if (typeof obj === "undefined") {
@@ -45,6 +46,18 @@ const assertIsObject = (
     throw new TypeError(`Microformats parser: ${name} cannot be null`);
   }
 
+  const unknownKeys = Object.keys(obj).filter(
+    (key) => !allowedKeys.includes(key)
+  );
+
+  if (unknownKeys.length) {
+    throw new TypeError(
+      `Microformats parser: ${name} contains unknown properties: ${unknownKeys.join(
+        ", "
+      )}`
+    );
+  }
+
   return obj as Record<string, unknown>;
 };
 
@@ -54,7 +67,11 @@ export const validator = (
 ): void => {
   assertIsString(unknownHtml, "HTML");
 
-  const options = assertIsObject(unknownOptions, "options");
+  const options = assertIsObject(
+    unknownOptions,
+    ["baseUrl", "experimental"],
+    "options"
+  );
 
   const baseUrl = assertIsString(options.baseUrl, "baseUrl");
 
@@ -62,7 +79,11 @@ export const validator = (
   new URL(baseUrl);
 
   if ("experimental" in options) {
-    const experimental = assertIsObject(options.experimental, "experimental");
+    const experimental = assertIsObject(
+      options.experimental,
+      ["lang"],
+      "experimental"
+    );
 
     if ("lang" in experimental) {
       assertIsBoolean(experimental.lang, "experimental.lang");

--- a/test/validation.spec.ts
+++ b/test/validation.spec.ts
@@ -78,6 +78,12 @@ describe("validation", () => {
       );
     });
 
+    it("should throw an error if it contains unknown keys", () => {
+      expect(() => mf2(html, { random: true })).to.throw(
+        "Microformats parser: options contains unknown properties: random"
+      );
+    });
+
     describe("baseUrl", () => {
       it("should throw an error if it is not provided", () => {
         expect(() => mf2(html, {})).to.throw(
@@ -124,6 +130,17 @@ describe("validation", () => {
         expect(() =>
           mf2(html, { baseUrl: "http://example.com", experimental: [] })
         ).to.throw("Microformats parser: experimental is not an object");
+      });
+
+      it("should throw an error if it contains unknown keys", () => {
+        expect(() =>
+          mf2(html, {
+            baseUrl: "http://example.com",
+            experimental: { random: true },
+          })
+        ).to.throw(
+          "Microformats parser: experimental contains unknown properties: random"
+        );
       });
 
       describe("lang", () => {


### PR DESCRIPTION
Adds validation for unknown keys in the `options` object.

For example:

```typescript
mf2(html, { random: true })
```

Will throw `TypeError: Microformats parser: options contains unknown properties: random`