### PR TITLE
docs(demo): add experimental lang options

### DIFF
--- a/demo/demo.css
+++ b/demo/demo.css
@@ -117,7 +117,7 @@ form label {
   padding: 1rem 0;
 }
 
-form input,
+form input[type="text"],
 form textarea {
   width: 100%;
   display: block;
@@ -143,4 +143,13 @@ form textarea {
 
 .hide {
   display: none;
+}
+
+.experimental label {
+  display: inline-block;
+}
+
+h3 {
+  font-size: 1rem;
+  margin: 0;
 }

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -13,11 +13,11 @@ const setError = (error) => {
   el.classList.remove("hide");
 };
 
-const parse = (html, { baseUrl }) => {
+const parse = (html, options) => {
   document.getElementById("error").classList.add("hide");
 
   try {
-    const result = mf2(html, { baseUrl });
+    const result = mf2(html, options);
     setResult(result);
   } catch (err) {
     setError(err.message);
@@ -29,6 +29,7 @@ const parse = (html, { baseUrl }) => {
 window.parseHtml = () => {
   const html = document.getElementById("html").value;
   const baseUrl = document.getElementById("base-url").value;
+  const lang = document.getElementById("lang").checked;
 
-  return parse(html, { baseUrl });
+  return parse(html, { baseUrl, experimental: { lang } });
 };

--- a/demo/index.html
+++ b/demo/index.html
@@ -38,6 +38,13 @@
     </header>
     <main class="container">
       <h2>Try it out</h2>
+      <noscript>
+        <div class="error">
+          <h1>JavaScript is disabled</h1>
+          <p>It looks like you have JavaScript disabled.</p>
+          <p>You need JavaScript to be enabled to view the demo.</p>
+        </div>
+      </noscript>
       <form onsubmit="return parseHtml()">
         <label>
           <span>Base URL</span>
@@ -49,6 +56,14 @@
           <textarea name="html" id="html"></textarea>
         </label>
 
+        <h3>Experimental options</h3>
+        <p class="experimental">
+          <label>
+            <input type="checkbox" name="lang" id="lang" value="true" checked />
+            <span>Language parsing</span>
+          </label>
+        </p>
+
         <div class="submit">
           <button type="submit">Parse</button>
         </div>
@@ -59,16 +74,6 @@
         <pre id="result"></pre>
       </div>
     </main>
-    <noscript>
-      <div class="error">
-        <h1>JavaScript is disabled</h1>
-        <p>It looks like you have JavaScript disabled.</p>
-        <p>
-          You need JavaScript to be enabled to view the demo; it's a JavaScript
-          component!
-        </p>
-      </div>
-    </noscript>
     <footer>
       <div class="container">
         <a href="{{ licenseUrl }}">{{ license }} Licensed</a>


### PR DESCRIPTION
Fixes #24.

**Checklist**

- [x] Linked to any relevant issues this will close.
- [x] Tested the output using the [demo](../CONTRIBUTING.md#testing-your-changes).

**Other changes**

Adds an experimental section to the demo, along with a language parsing option:

![image](https://user-images.githubusercontent.com/12508200/82117627-2406b100-9769-11ea-83a9-2e42e67bfc0e.png)

