### PR TITLE
fix(urls): trim all URLs for whitespace

### DIFF
--- a/src/helpers/documentSetup.ts
+++ b/src/helpers/documentSetup.ts
@@ -82,6 +82,8 @@ const handleNode = (
 
       if (attr && isLocalLink(attr.value)) {
         attr.value = applyBaseUrl(attr.value, result.baseUrl);
+      } else if (attr) {
+        attr.value = attr.value.trim();
       }
     });
 

--- a/src/helpers/textContent.ts
+++ b/src/helpers/textContent.ts
@@ -36,7 +36,7 @@ const impliedWalk = (current: string, node: DefaultTreeNode): string => {
     }
 
     if (node.tagName === "img") {
-      const value = getAttributeValue(node, "alt");
+      const value = getAttributeValue(node, "alt") || "";
       return `${current}${value}`;
     }
 

--- a/src/microformats/property.ts
+++ b/src/microformats/property.ts
@@ -50,9 +50,11 @@ export const parseU = (
     getAttributeIfTag(node, ["data", "input"], "value") ??
     textContent(node);
 
-  return typeof url === "string" && isLocalLink(url)
-    ? applyBaseUrl(url, options.baseUrl)
-    : url;
+  if (typeof url === "string" && isLocalLink(url)) {
+    return applyBaseUrl(url, options.baseUrl);
+  }
+
+  return typeof url === "string" ? url.trim() : url;
 };
 
 const parseDt = (node: DefaultTreeElement): string =>

--- a/src/rels/rels.ts
+++ b/src/rels/rels.ts
@@ -13,9 +13,14 @@ export const parseRel = (
   child: DefaultTreeElement,
   { rels, relUrls }: ParseRelOptions
 ): void => {
+  /**
+   * Ignores used as this metho is only ever called if they are defined
+   * But required for TS typechecking
+   */
   const text = relTextContent(child);
   const rel = getAttributeValue(child, "rel");
-  const href = getAttributeValue(child, "href");
+  /* istanbul ignore next */
+  const href = getAttributeValue(child, "href")?.trim();
   const title = getAttributeValue(child, "title");
   const media = getAttributeValue(child, "media");
   const hreflang = getAttributeValue(child, "hreflang");

--- a/test/suites/local/microformats-v2/rel-urls.html
+++ b/test/suites/local/microformats-v2/rel-urls.html
@@ -1,3 +1,9 @@
 <link rel="me" href="http://example.com" />
+
 <a rel="me" href="http://example.com" type="text/html">My name</a>
+
 <a rel="home" href="http://example.com">Go back home</a>
+
+<a rel="example" href="    http://example.com   ">This URL should be trimmed</a>
+
+<a rel="no-href">This should be ignored</a>

--- a/test/suites/local/microformats-v2/rel-urls.json
+++ b/test/suites/local/microformats-v2/rel-urls.json
@@ -1,11 +1,12 @@
 {
   "rels": {
     "me": ["http://example.com"],
-    "home": ["http://example.com"]
+    "home": ["http://example.com"],
+    "example": ["http://example.com"]
   },
   "rel-urls": {
     "http://example.com": {
-      "rels": ["me", "home"],
+      "rels": ["me", "home", "example"],
       "text": "My name",
       "type": "text/html"
     }

--- a/test/suites/local/microformats-v2/urls.html
+++ b/test/suites/local/microformats-v2/urls.html
@@ -11,3 +11,37 @@
 <div class="h-entry">
   <link class="u-url" href="http://example.com/" />
 </div>
+
+<div class="h-entry">
+  <a class="u-url" href="    http://example.com/    ">Example post</a>
+</div>
+
+<div class="h-entry">
+  <a class="u-url" href="    ./relative/path.html    ">Example post</a>
+</div>
+
+<div class="h-entry">
+  <div class="e-content">
+    <a href="    http://example.com/    ">Example post</a>
+  </div>
+</div>
+
+<div class="h-entry">
+  <div class="e-content">
+    <a href="    ./relative/path.html    ">Example post</a>
+  </div>
+</div>
+
+<div class="h-entry">
+  <data class="u-url" value="    http://example.com/    ">A data value</data>
+</div>
+
+<div class="h-entry">
+  <img class="u-photo" src="    http://example.com/photo.jpg    " />
+  An image to be trimmed
+</div>
+
+<div class="h-entry">
+  <img class="u-photo" src="    http://example.com/photo.jpg    " alt="Photo" />
+  An image to be trimmed
+</div>

--- a/test/suites/local/microformats-v2/urls.json
+++ b/test/suites/local/microformats-v2/urls.json
@@ -27,6 +27,71 @@
         "name": [""],
         "url": ["http://example.com/"]
       }
+    },
+    {
+      "type": ["h-entry"],
+      "properties": {
+        "name": ["Example post"],
+        "url": ["http://example.com/"]
+      }
+    },
+    {
+      "type": ["h-entry"],
+      "properties": {
+        "name": ["Example post"],
+        "url": ["http://example.com/relative/path.html"]
+      }
+    },
+    {
+      "type": ["h-entry"],
+      "properties": {
+        "url": ["http://example.com/"],
+        "content": [
+          {
+            "value": "Example post",
+            "html": "<a href=\"http://example.com/\">Example post</a>"
+          }
+        ]
+      }
+    },
+    {
+      "type": ["h-entry"],
+      "properties": {
+        "url": ["http://example.com/relative/path.html"],
+        "content": [
+          {
+            "value": "Example post",
+            "html": "<a href=\"http://example.com/relative/path.html\">Example post</a>"
+          }
+        ]
+      }
+    },
+    {
+      "type": ["h-entry"],
+      "properties": {
+        "name": ["A data value"],
+        "url": ["http://example.com/"]
+      }
+    },
+
+    {
+      "properties": {
+        "name": ["An image to be trimmed"],
+        "photo": ["http://example.com/photo.jpg"]
+      },
+      "type": ["h-entry"]
+    },
+    {
+      "properties": {
+        "name": ["Photo"],
+        "photo": [
+          {
+            "alt": "Photo",
+            "value": "http://example.com/photo.jpg"
+          }
+        ]
+      },
+      "type": ["h-entry"]
     }
   ],
   "rels": {},


### PR DESCRIPTION
**Checklist**

- [x] Added tests covering the parsing behaviour changes.

**Changes to parsing behaviour**

URLs are now trimmed, following https://github.com/microformats/microformats2-parsing/issues/48

A brief summary of any changes to the parser behaviour.