### PR TITLE
fix(package): remove redundant `files` entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
   },
   "files": [
     "/dist",
-    "/README.md",
-    "/LICENSE",
     "/CONTRIBUTING.md"
   ],
   "dependencies": {


### PR DESCRIPTION
The `README` and `LICENSE` files are always implicitly included by NPM.

You can see yourself by running `$ npm pack --dry-run`, which lists the included files.

See also: https://docs.npmjs.com/files/package.json#files