### PR TITLE
fix(docs): change readme to commonjs import

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm i microformats-parser
 ### Simple use
 
 ```javascript
-import { mf2 } from "microformats-parser";
+const { mf2 } = require("microformats-parser");
 
 const parsed = mf2('<a class="h-card" href="/" rel="me">Jimmy</a>', {
   baseUrl: "http://example.com/",


### PR DESCRIPTION
In response to #39.

**Checklist**

- [x] Linked to any relevant issues this will close.

**Other changes**

Updates the README to specify the commonjs import (not TypeScript) to make it clearer how to import the package.
